### PR TITLE
DebugPanel was renamed to Panel

### DIFF
--- a/debug_toolbar_user_panel/panels.py
+++ b/debug_toolbar_user_panel/panels.py
@@ -60,12 +60,12 @@ from django.utils.translation import ugettext_lazy as _
 
 from django.contrib.auth import get_user_model
 
-from debug_toolbar.panels import DebugPanel
+from debug_toolbar.panels import Panel
 
 from . import views
 from .forms import UserForm
 
-class UserPanel(DebugPanel):
+class UserPanel(Panel):
     """
     Panel that allows you to login as other recently-logged in users.
     """


### PR DESCRIPTION
Backward-compatibility for 1.0, remove in 2.0